### PR TITLE
fix(replay): 进入回放前先退出当前世界或服务器

### DIFF
--- a/src/main/java/top/fpsmaster/replay/ReplayPlayer.java
+++ b/src/main/java/top/fpsmaster/replay/ReplayPlayer.java
@@ -289,11 +289,18 @@ public final class ReplayPlayer {
     /**
      * Builds the world the recording will be poured into.
      *
+     * <p>A live singleplayer or multiplayer session is torn down first.
+     * {@code loadWorld(WorldClient)} does not disconnect: it leaves the old
+     * {@code NetworkManager} open, so spectator movement is still sent to the
+     * real server.
+     *
      * <p>This is what {@code handleJoinGame} does, minus its one Forge call: that resolves the
      * dimension through the connection's Netty channel, and playback has no channel.
      */
     private void openWorld(ReplayFile.Header header) {
         Minecraft mc = Minecraft.getMinecraft();
+        leaveCurrentSession(mc);
+
         NetworkManager connection = new SilentConnection();
         netHandler = new NetHandlerPlayClient(mc, null, connection, recorderProfile);
         connection.setNetHandler(netHandler);
@@ -309,6 +316,29 @@ public final class ReplayPlayer {
         mc.thePlayer.setEntityId(CAMERA_ENTITY_ID);
         mc.playerController.setGameType(WorldSettings.GameType.SPECTATOR);
         mc.displayGuiScreen(null);
+    }
+
+    /**
+     * Leaves the current singleplayer world or multiplayer server the way the in-game Disconnect
+     * button does, without flashing a menu in between.
+     *
+     * <p>{@code Minecraft.loadWorld} only closes the connection and shuts down the integrated
+     * server when the argument is {@code null}. Loading a replay world on top of a live one keeps
+     * the old handler and the live player entity, so flight in the replay is still sent upstream.
+     */
+    private static void leaveCurrentSession(Minecraft mc) {
+        if (mc.theWorld == null && mc.thePlayer == null && mc.getNetHandler() == null) {
+            return;
+        }
+        ClientLogger.info("replay", "leaving current world/server before playback");
+        if (mc.theWorld != null) {
+            try {
+                mc.theWorld.sendQuittingDisconnectingPacket();
+            } catch (Exception failure) {
+                ClientLogger.warn("replay -> failed to send quit packet: " + failure.getMessage(), failure);
+            }
+        }
+        mc.loadWorld(null);
     }
 
     public synchronized void stop() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
在世界或服务器里点播放时，回放世界会直接 `loadWorld(replayWorld)`，**不会**走 Disconnect 路径。1.8.9 的 `loadWorld(新世界)` 不会 `cleanup()` 旧 `NetHandlerPlayClient`，也不会关 integrated server，旧 `NetworkManager` 继续开着。旁观飞行仍按原 `thePlayer.sendQueue` 发到真实服务器，表现为飞行等异常。

## 改动

`ReplayPlayer.openWorld` 在搭 SilentConnection / 回放 `WorldClient` 之前先 `leaveCurrentSession()`：

1. 有现世时走和菜单 Disconnect / Shortcut `QUIT_NETWORK` 相同的 `sendQuittingDisconnectingPacket()`
2. 再 `loadWorld(null)`，关掉连接并停掉 integrated server
3. **不**中间弹出多人游戏/主菜单；`ReplayScreen` 保持到回放世界就绪后 `displayGuiScreen(null)`

`sendQueue` 缺失时只记 warn，仍继续 `loadWorld(null)`。

Seek / 重开已有回放时 `start()` 会先 `stop()` 卸掉回放世界，此时 `theWorld` 已是 null，`leaveCurrentSession` 是空操作。

## 验证

- [ ] 单人世界里打开回放：应退出该世界（integrated server 停掉），不再向它发包
- [ ] 多人服务器里打开回放：应断开服务器，旁观移动不再发到原服
- [ ] 主菜单打开回放：行为不变
- [ ] 回放中 seek / 重开同一文件：不误伤、不闪菜单
- 本环境无法启动 1.8.9 客户端，未做游戏内实测；`./gradlew test` 覆盖现有单元测试

## 范围

只改 Edge 回放进入路径。Nova 同问题另开 PR。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f5b41f4-18fa-4457-9810-07f162ea5de2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f5b41f4-18fa-4457-9810-07f162ea5de2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

